### PR TITLE
Reset access array for each resource

### DIFF
--- a/src/Acl.php
+++ b/src/Acl.php
@@ -143,7 +143,9 @@ class Acl
     {
         foreach ($arr as $key => $value) {
             $this->resources[$nkey . $key] = array();
-            
+
+            $access = [];
+
             if (isset($value['access']) && is_array($value['access'])) {
                 foreach ($value['access'] as $acc) {
                     if (!in_array($acc, $access)) {


### PR DESCRIPTION
Fixes an issue when sibling resources would inherit each others' permissions
@hostinger/devs 